### PR TITLE
fix: align solo score calc with battle damage

### DIFF
--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -252,7 +252,10 @@ export function createInitialSoloState(seed: string): SoloState {
 export function advanceSoloState(
     state: SoloState,
     seed: string,
-    selectedPrime: Prime
+    selectedPrime: Prime,
+    options?: {
+        resolvingQueueLength?: number;
+    }
 ): SoloState {
     const outcome = applyPrimeSelection(state.currentStage, selectedPrime);
 
@@ -264,13 +267,14 @@ export function advanceSoloState(
         return {
             ...state,
             currentStage: outcome.stage,
-            score: state.score + 10,
+            score: state.score + computeBattleFactorDamage(selectedPrime),
         };
     }
 
     const nextStageIndex = state.clearedStages + 1;
-    const nextCombo = state.combo + 1;
-    const comboBonus = nextCombo * 15;
+    const nextCombo = Math.max(1, options?.resolvingQueueLength ?? 1);
+    const factorDamage = computeBattleFactorDamage(selectedPrime);
+    const comboDamage = computeBattleComboDamage(nextCombo);
 
     return {
         hp: Math.min(
@@ -279,7 +283,7 @@ export function advanceSoloState(
         ),
         combo: nextCombo,
         maxCombo: Math.max(state.maxCombo, nextCombo),
-        score: state.score + 50 + comboBonus,
+        score: state.score + factorDamage + comboDamage,
         clearedStages: nextStageIndex,
         currentStage: generateStage(seed, nextStageIndex),
     };

--- a/src/hooks/useSoloGame.ts
+++ b/src/hooks/useSoloGame.ts
@@ -66,6 +66,7 @@ export function useSoloGame({
     const [isNewBest, setIsNewBest] = useState(false);
     const latestSoloStateRef = useRef(soloState);
     const isPausedRef = useRef(false);
+    const submittedSoloQueueLengthRef = useRef(0);
 
     const soloCountdownProgress = (soloTimeLeft / soloDurationSeconds) * 100;
 
@@ -149,6 +150,7 @@ export function useSoloGame({
                 if (outcome.kind === 'wrong') {
                     setSoloState(applySoloPenalty(currentState));
                     setSoloPrimeQueue([]);
+                    submittedSoloQueueLengthRef.current = 0;
                     setSoloTimeLeft((currentTime) =>
                         Math.max(0, currentTime - 1)
                     );
@@ -157,13 +159,21 @@ export function useSoloGame({
                     return;
                 }
 
+                const hasRedundantBufferedPrimes =
+                    outcome.cleared && soloPrimeQueue.length > 1;
+                const resolvingQueueLength =
+                    !outcome.cleared || hasRedundantBufferedPrimes
+                        ? undefined
+                        : submittedSoloQueueLengthRef.current;
+
                 const nextState = advanceSoloState(
                     currentState,
                     soloSeed,
-                    nextPrime
+                    nextPrime,
+                    {
+                        resolvingQueueLength,
+                    }
                 );
-                const hasRedundantBufferedPrimes =
-                    outcome.cleared && soloPrimeQueue.length > 1;
 
                 if (hasRedundantBufferedPrimes) {
                     setSoloStageAdvanceSolvedStateKey(
@@ -171,6 +181,7 @@ export function useSoloGame({
                     );
                     setSoloState(applySoloPenalty(nextState));
                     setSoloPrimeQueue([]);
+                    submittedSoloQueueLengthRef.current = 0;
                     setSoloTimeLeft((currentTime) =>
                         Math.max(0, currentTime - 1)
                     );
@@ -186,6 +197,7 @@ export function useSoloGame({
                 );
 
                 if (outcome.cleared) {
+                    submittedSoloQueueLengthRef.current = 0;
                     setSoloStageAdvanceSolvedStateKey(
                         (currentKey) => currentKey + 1
                     );
@@ -206,6 +218,7 @@ export function useSoloGame({
             return;
         }
 
+        submittedSoloQueueLengthRef.current = queue.length;
         setSoloPrimeQueue([...queue]);
         setIsSoloComboRunning(true);
     }
@@ -217,6 +230,7 @@ export function useSoloGame({
         setSoloState(createInitialSoloState(nextSoloSeed));
         setSoloTimeLeft(soloDurationSeconds);
         setSoloPrimeQueue([]);
+        submittedSoloQueueLengthRef.current = 0;
         setIsSoloComboRunning(false);
         setSoloStageAdvanceSolvedStateKey(0);
         setSoloTimerPenaltyPopKey(0);
@@ -228,6 +242,7 @@ export function useSoloGame({
 
     function resetSoloGame() {
         setSoloPrimeQueue([]);
+        submittedSoloQueueLengthRef.current = 0;
         setIsSoloComboRunning(false);
         setSoloStageAdvanceSolvedStateKey(0);
         setSoloTimerPenaltyPopKey(0);


### PR DESCRIPTION
## Summary
- align solo scoring with the multiplayer damage helpers
- use the submitted queue length for solo combo bonus calculation
- preserve redundant-input penalty behavior while preventing false combo credit

## Verification
- bun run build
- Playwright localhost check on solo gameplay: verified a live 231 = 3×7×11 clear scored 37 total (21 factor damage + 16 combo bonus)