### PR TITLE
fix: prevent keypad focus duplicate entry

### DIFF
--- a/src/components/game/ui/PrimeKeyButton.tsx
+++ b/src/components/game/ui/PrimeKeyButton.tsx
@@ -30,6 +30,7 @@ export function PrimeKeyButton({
             return;
         }
 
+        event.preventDefault();
         onPress(prime);
     }
 
@@ -43,6 +44,7 @@ export function PrimeKeyButton({
         }
 
         event.preventDefault();
+        event.stopPropagation();
         onPress(prime);
     }
 

--- a/src/hooks/useMultiplayerGame.ts
+++ b/src/hooks/useMultiplayerGame.ts
@@ -916,7 +916,7 @@ export function useMultiplayerGame({
         let timeoutId: number | undefined;
 
         try {
-            const response = await Promise.race<'ok' | 'timed out' | 'error'>([
+            const response = await Promise.race([
                 channel.send({
                     type: 'broadcast',
                     event: message.type,


### PR DESCRIPTION
## Description

Fixes #22.

Clicking a prime keypad button could leave browser focus on that button. Pressing hardware Enter afterward could activate the focused prime button while the global game keyboard handler also treated Enter as submit, causing duplicate factor input.

This change prevents pointer presses from focusing prime keypad buttons and stops keyboard activation on a prime button from bubbling into the global game keyboard controls.