### PR TITLE
fix: limit new best to high scores

### DIFF
--- a/src/lib/app-helpers.ts
+++ b/src/lib/app-helpers.ts
@@ -140,11 +140,10 @@ export function loadBestScore(): BestScoreRecord {
 
 export function saveBestScore(score: number, maxCombo: number): boolean {
     const current = loadBestScore();
-    let updated = false;
+    const isNewHighScore = score > current.score;
 
-    if (score > current.score) {
+    if (isNewHighScore) {
         globalThis.localStorage.setItem(bestScoreStorageKey, String(score));
-        updated = true;
     }
 
     if (maxCombo > current.maxCombo) {
@@ -152,10 +151,9 @@ export function saveBestScore(score: number, maxCombo: number): boolean {
             bestMaxComboStorageKey,
             String(maxCombo)
         );
-        updated = true;
     }
 
-    return updated;
+    return isNewHighScore;
 }
 
 export function isTutorialComplete(): boolean {


### PR DESCRIPTION
## Description

Fixes #19.

`saveBestScore()` now reports a new best only when the score beats the previous high score. Higher max combos are still saved, but combo-only improvements no longer show the New Best badge or trigger the high-score upload path.