### PR TITLE
Finish Godot mobile port export config

### DIFF
--- a/godot/README.md
+++ b/godot/README.md
@@ -151,8 +151,9 @@ needed unless you are deliberately adding C# code.
 
 3. Run the game in the editor with the play button, or press `F5`.
 
-The main scene is `res://scenes/Main.tscn`. It is a solo gameplay harness for
-device latency testing, not a full replacement for the Vite UI yet.
+The main scene is `res://scenes/Main.tscn`. It includes the mobile home,
+tutorial, solo, leaderboard, realtime lobby presence, and CPU battle flows.
+Account management, friends, and full web/PWA routing stay in the Vite app.
 
 ## Short Path
 

--- a/scripts/godot/export-mobile.ts
+++ b/scripts/godot/export-mobile.ts
@@ -26,6 +26,7 @@ if (target !== 'android' && target !== 'ios') {
 }
 
 const exportConfig = exportsByTarget[target];
+const godotBinary = requireGodotBinary();
 mkdirSync(path.dirname(exportConfig.outputPath), { recursive: true });
 const buildDirectory = path.resolve(GODOT_DIRECTORY, 'build');
 mkdirSync(buildDirectory, { recursive: true });
@@ -76,6 +77,29 @@ function setApplicationSetting(
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = process.env.VITE_SUPABASE_ANON_KEY;
+const iosTeamId = process.env.GODOT_IOS_TEAM_ID;
+let nextExportPresets = originalExportPresets;
+
+if (target === 'ios') {
+    if (!iosTeamId) {
+        console.error(
+            '[Error] Set GODOT_IOS_TEAM_ID in .env.local before exporting iOS builds.'
+        );
+        process.exit(1);
+    }
+
+    nextExportPresets = originalExportPresets.replace(
+        /application\/app_store_team_id="[^"]*"/,
+        `application/app_store_team_id="${iosTeamId}"`
+    );
+
+    if (nextExportPresets === originalExportPresets) {
+        console.error(
+            '[Error] Could not find application/app_store_team_id in godot/export_presets.cfg.'
+        );
+        process.exit(1);
+    }
+}
 
 if (supabaseUrl && supabaseAnonKey) {
     const nextProjectSettings = setApplicationSetting(
@@ -97,27 +121,6 @@ if (supabaseUrl && supabaseAnonKey) {
 }
 
 if (target === 'ios') {
-    const iosTeamId = process.env.GODOT_IOS_TEAM_ID;
-
-    if (!iosTeamId) {
-        console.error(
-            '[Error] Set GODOT_IOS_TEAM_ID in .env.local before exporting iOS builds.'
-        );
-        process.exit(1);
-    }
-
-    const nextExportPresets = originalExportPresets.replace(
-        /application\/app_store_team_id="[^"]*"/,
-        `application/app_store_team_id="${iosTeamId}"`
-    );
-
-    if (nextExportPresets === originalExportPresets) {
-        console.error(
-            '[Error] Could not find application/app_store_team_id in godot/export_presets.cfg.'
-        );
-        process.exit(1);
-    }
-
     writeFileSync(exportPresetsPath, nextExportPresets);
     shouldRestoreExportPresets = true;
 }
@@ -125,7 +128,7 @@ if (target === 'ios') {
 const result = (() => {
     try {
         return spawnSync(
-            requireGodotBinary(),
+            godotBinary,
             [
                 '--headless',
                 '--path',

--- a/scripts/godot/load-local-env.ts
+++ b/scripts/godot/load-local-env.ts
@@ -8,7 +8,9 @@ function isSupportedEnvKey(key: string): boolean {
     return (
         key.startsWith('GODOT_') ||
         key.startsWith('IOS_') ||
-        key === 'APPLE_TEAM_ID'
+        key === 'APPLE_TEAM_ID' ||
+        key === 'VITE_SUPABASE_ANON_KEY' ||
+        key === 'VITE_SUPABASE_URL'
     );
 }
 


### PR DESCRIPTION
## Description

Closes #37.

- Allow Godot mobile export scripts to load `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` from `.env.local`, matching the documented setup path for Supabase-backed mobile builds.
- Update the Godot README status text to describe the current mobile port coverage and the web-only surfaces that remain in Vite.