### PR TITLE
feat: add advancement progression

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,11 +15,14 @@ import { useMultiplayerGame } from './hooks/useMultiplayerGame';
 import { useSoloGame } from './hooks/useSoloGame';
 import { useTutorialGame } from './hooks/useTutorialGame';
 import {
+    addExperience,
     calculateLevel,
     detachPromise,
     getInitialPlayerName,
+    getSoloExpGain,
     isGuestModeEnabled,
     loadBestScore,
+    loadExperience,
     markTutorialComplete,
     normalizeHistoricSoloHighScore,
     persistPlayerName,
@@ -185,6 +188,7 @@ async function syncAuthenticatedLeaderboardProfile({
 }) {
     const userId = currentSession.user.id;
     const fallbackHighScore = loadBestScore().score;
+    const fallbackExperience = loadExperience();
     const existingRecordResponse = await authClient
         .from('combo_leaderboard')
         .select('player_name, high_score, experience, updated_at')
@@ -207,6 +211,10 @@ async function syncAuthenticatedLeaderboardProfile({
             existingRecord?.updated_at
         ),
         fallbackHighScore
+    );
+    const nextExperience = Math.max(
+        existingRecord?.experience ?? 0,
+        fallbackExperience
     );
 
     if (nextHighScore > 0) {
@@ -242,6 +250,7 @@ async function syncAuthenticatedLeaderboardProfile({
             user_id: userId,
             player_name: nextPlayerName,
             high_score: nextHighScore,
+            experience: nextExperience,
         },
         { onConflict: 'user_id' }
     );
@@ -261,7 +270,7 @@ async function syncAuthenticatedLeaderboardProfile({
         );
     }
 
-    return calculateLevel(existingRecord?.experience ?? 0);
+    return calculateLevel(nextExperience);
 }
 
 const SCREEN_TO_PATH = {
@@ -354,8 +363,7 @@ export default function App(): JSX.Element {
                         currentSession: data.session,
                         fallbackName: getAuthDisplayName(
                             data.session.user.user_metadata as
-                                | Record<string, unknown>
-                                | undefined,
+                                Record<string, unknown> | undefined,
                             data.session.user.email
                         ),
                         onPlayerName: setPlayerName,
@@ -383,8 +391,7 @@ export default function App(): JSX.Element {
                             currentSession,
                             fallbackName: getAuthDisplayName(
                                 currentSession.user.user_metadata as
-                                    | Record<string, unknown>
-                                    | undefined,
+                                    Record<string, unknown> | undefined,
                                 currentSession.user.email
                             ),
                             onPlayerName: setPlayerName,
@@ -404,8 +411,50 @@ export default function App(): JSX.Element {
     }, []);
 
     const [playerName, setPlayerName] = useState(() => getInitialPlayerName());
-    const [playerLevel, setPlayerLevel] = useState<number | undefined>(
-        undefined
+    const [playerLevel, setPlayerLevel] = useState(() =>
+        calculateLevel(loadExperience())
+    );
+    const awardExperience = useCallback(
+        (experienceGain: number) => {
+            const normalizedGain = Math.max(0, Math.floor(experienceGain));
+
+            if (normalizedGain === 0) {
+                return;
+            }
+
+            const userId = session?.user.id;
+            const authClient = supabaseAuthClient;
+
+            if (!authClient || !userId) {
+                setPlayerLevel(calculateLevel(addExperience(normalizedGain)));
+                return;
+            }
+
+            detachPromise(
+                Promise.resolve(
+                    authClient
+                        .rpc('add_solo_exp', {
+                            p_user_id: userId,
+                            p_exp_gain: normalizedGain,
+                        })
+                        .then(() =>
+                            authClient
+                                .from('combo_leaderboard')
+                                .select('experience')
+                                .eq('user_id', userId)
+                                .single()
+                        )
+                        .then((res) => {
+                            if (res.data) {
+                                setPlayerLevel(
+                                    calculateLevel(res.data.experience)
+                                );
+                            }
+                        })
+                )
+            );
+        },
+        [session?.user.id]
     );
     const soloGame = useSoloGame({
         screen,
@@ -429,45 +478,17 @@ export default function App(): JSX.Element {
             );
         },
         onGameFinish: (score) => {
-            const userId = session?.user.id;
-            const authClient = supabaseAuthClient;
-            if (!authClient || !userId) {
-                return;
-            }
-            const expGain = Math.floor(score / 10);
-            if (expGain > 0) {
-                detachPromise(
-                    Promise.resolve(
-                        authClient
-                            .rpc('add_solo_exp', {
-                                p_user_id: userId,
-                                p_exp_gain: expGain,
-                            })
-                            .then(() =>
-                                authClient
-                                    .from('combo_leaderboard')
-                                    .select('experience')
-                                    .eq('user_id', userId)
-                                    .single()
-                            )
-                            .then((res) => {
-                                if (res.data) {
-                                    setPlayerLevel(
-                                        calculateLevel(res.data.experience)
-                                    );
-                                }
-                            })
-                    )
-                );
-            }
+            awardExperience(getSoloExpGain(score));
         },
     });
     const multiplayerGame = useMultiplayerGame({
+        onBattleFinish: awardExperience,
         playerName,
         screen,
         onScreenChange,
     });
     const localCpuGame = useLocalCpuGame({
+        onBattleFinish: awardExperience,
         playerName,
         screen,
         onScreenChange,
@@ -700,7 +721,7 @@ export default function App(): JSX.Element {
         setIsGuest(true);
         setGuestModeEnabled(true);
         setPlayerName('');
-        setPlayerLevel(undefined);
+        setPlayerLevel(calculateLevel(loadExperience()));
         persistPlayerName('');
     }
 

--- a/src/app-state.ts
+++ b/src/app-state.ts
@@ -125,6 +125,8 @@ export const uiText = {
     wins: 'Wins',
     losses: 'Losses',
     winRate: 'Win Rate',
+    levelLabel: 'Lv.',
+    exp: 'EXP',
     loginError: 'Could not start Google log in.',
     emailLoginError: 'Could not log in with email and password.',
     emailSignupError: 'Could not create your account.',

--- a/src/components/game/MultiplayerGameScreen.tsx
+++ b/src/components/game/MultiplayerGameScreen.tsx
@@ -11,6 +11,7 @@ import type {
     SideHpImpacts,
 } from '../../hooks/useBattleAnimations';
 import { usePrimeKeyboardControls } from '../../hooks/usePrimeKeyboardControls';
+import { getBattleExpGain } from '../../lib/app-helpers';
 import {
     getTutorialAction,
     getTutorialExpectedQueue,
@@ -81,6 +82,18 @@ export function MultiplayerGameScreen({
     const currentPlayerWon =
         isMatchFinished &&
         Boolean(currentMultiplayerPlayer && currentMultiplayerPlayer.hp > 0);
+    const currentPlayerTied =
+        isMatchFinished &&
+        Boolean(
+            currentMultiplayerPlayer &&
+            currentMultiplayerPlayer.hp <= 0 &&
+            opponentPlayer &&
+            opponentPlayer.hp <= 0
+        );
+    const battleExpGained = getBattleExpGain(
+        currentPlayerWon,
+        currentPlayerTied
+    );
     const tutorial = useBattleTutorial({
         battleVisualsBusy: battle.isAnimating,
         currentPlayer: currentMultiplayerPlayer,
@@ -350,18 +363,7 @@ export function MultiplayerGameScreen({
                             atomized: currentMultiplayerPlayer?.stageIndex ?? 0,
                             isWinner: currentPlayerWon,
                         }}
-                        expGained={(() => {
-                            if (currentPlayerWon) {
-                                return 150;
-                            }
-                            if (
-                                currentMultiplayerPlayer?.hp === 0 &&
-                                opponentPlayer?.hp === 0
-                            ) {
-                                return 50;
-                            }
-                            return 30;
-                        })()}
+                        expGained={battleExpGained}
                         mode='battle'
                         onRematch={onRematch}
                         onReturnHome={onBack}

--- a/src/components/game/SingleGameScreen.tsx
+++ b/src/components/game/SingleGameScreen.tsx
@@ -5,6 +5,7 @@ import { uiText } from '../../app-state';
 import type { SoloState } from '../../core/game';
 import type { Prime } from '../../core/primes';
 import { usePrimeKeyboardControls } from '../../hooks/usePrimeKeyboardControls';
+import { getSoloExpGain } from '../../lib/app-helpers';
 import type { BestScoreRecord } from '../../lib/app-helpers';
 
 import './GamePlayScreen.css';
@@ -215,7 +216,7 @@ export function SingleGameScreen({
                         atomized={soloState.clearedStages}
                         bestScore={bestScore.score}
                         comboCount={soloState.maxCombo}
-                        expGained={Math.floor(soloState.score / 10)}
+                        expGained={getSoloExpGain(soloState.score)}
                         isNewBest={isNewBest}
                         mode='solo'
                         onRetry={handleRetry}

--- a/src/components/game/ui/ScoreDialog.tsx
+++ b/src/components/game/ui/ScoreDialog.tsx
@@ -81,7 +81,10 @@ export function ScoreDialog(props: ScoreDialogProps): JSX.Element {
 
                 {props.mode === 'battle' ? (
                     <div className='score-dialog-players'>
-                        <PlayerColumn expGained={props.expGained} player={props.currentPlayer} />
+                        <PlayerColumn
+                            expGained={props.expGained}
+                            player={props.currentPlayer}
+                        />
                         <div
                             aria-hidden='true'
                             className='score-dialog-player-divider'
@@ -126,11 +129,12 @@ export function ScoreDialog(props: ScoreDialogProps): JSX.Element {
                                 label={uiText.maxCombo}
                                 value={props.comboCount}
                             />
-                            {props.expGained !== undefined && props.expGained > 0 ? (
-                                <div className='score-dialog-stat-row'>
-                                    <span className='score-dialog-stat-label'>EXP</span>
-                                    <span className='score-dialog-stat-value'>+{props.expGained}</span>
-                                </div>
+                            {props.expGained !== undefined &&
+                            props.expGained > 0 ? (
+                                <StatRow
+                                    label={uiText.exp}
+                                    value={`+${props.expGained}`}
+                                />
                             ) : undefined}
                         </div>
                     </>
@@ -171,7 +175,7 @@ function StatRow({
     value,
 }: {
     label: string;
-    value: number;
+    value: number | string;
 }): JSX.Element {
     return (
         <div className='score-dialog-stat-row'>
@@ -183,7 +187,13 @@ function StatRow({
 
 /* Battle player column */
 
-function PlayerColumn({ player, expGained }: { player: PlayerStats; expGained?: number }): JSX.Element {
+function PlayerColumn({
+    player,
+    expGained,
+}: {
+    player: PlayerStats;
+    expGained?: number;
+}): JSX.Element {
     const modifier = player.isWinner
         ? ' score-dialog-player--winner'
         : ' score-dialog-player--loser';
@@ -207,10 +217,7 @@ function PlayerColumn({ player, expGained }: { player: PlayerStats; expGained?: 
                 <StatRow label={uiText.atomized} value={player.atomized} />
                 <StatRow label={uiText.maxCombo} value={player.maxCombo} />
                 {expGained !== undefined && expGained > 0 ? (
-                    <div className='score-dialog-stat-row'>
-                        <span className='score-dialog-stat-label'>EXP</span>
-                        <span className='score-dialog-stat-value'>+{expGained}</span>
-                    </div>
+                    <StatRow label={uiText.exp} value={`+${expGained}`} />
                 ) : undefined}
             </div>
         </div>

--- a/src/components/menu/AccountScreen.css
+++ b/src/components/menu/AccountScreen.css
@@ -104,22 +104,24 @@
 .account-name-badge {
     appearance: none;
     background: transparent;
-    border: 2px solid #fff;
+    border: 2px solid var(--color-border-inverse-soft);
     border-radius: var(--radius-pill);
-    color: #fff;
+    color: var(--color-text-inverse);
     font-size: var(--type-title-size);
     font-weight: 700;
     padding: var(--space-1) var(--space-4);
     cursor: pointer;
-    transition: background 0.2s, color 0.2s;
+    transition:
+        background-color 0.2s,
+        color 0.2s;
 }
 
 .account-name-badge:hover {
-    background: rgba(255, 255, 255, 0.15);
+    background: var(--color-border-inverse-subtle);
 }
 
 .account-name-badge:active {
-    background: rgba(255, 255, 255, 0.25);
+    background: var(--color-border-contrast);
 }
 
 /* === Edit Name Dialog Body === */
@@ -147,49 +149,6 @@
     color: var(--color-muted);
 }
 
-.account-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--space-3);
-    margin-bottom: var(--space-4);
-}
-
-.account-stat-card {
-    background: var(--color-surface);
-    border: 1px solid var(--color-border-soft);
-    border-radius: var(--radius-surface);
-    padding: var(--space-3);
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    text-align: center;
-    gap: var(--space-1);
-}
-
-.account-stat-card:first-child {
-    grid-column: 1 / -1;
-    background: linear-gradient(135deg, var(--color-primary-soft), var(--color-surface));
-    border-color: var(--color-primary-strong);
-}
-
-.account-stat-card:first-child .stat-value {
-    color: var(--color-primary-strong);
-    font-size: 2rem;
-}
-
-.stat-label {
-    font-size: var(--type-body-meta-size);
-    color: var(--color-muted);
-    font-weight: 600;
-}
-
-.stat-value {
-    font-size: var(--type-title-size);
-    font-weight: 800;
-    color: var(--color-ink);
-}
-
 /* === EXP Banner === */
 .account-stats-container-inner {
     display: flex;
@@ -198,22 +157,34 @@
     width: 100%;
 }
 
-.account-exp-banner {
+.account-exp-stat {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
     gap: var(--space-2);
-    background: rgba(255, 255, 255, 0.05);
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: var(--radius-surface);
-    padding: var(--space-3);
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    backdrop-filter: blur(10px);
 }
 
 .account-exp-header {
     display: flex;
     justify-content: space-between;
     align-items: baseline;
-    font-weight: 700;
+    gap: var(--space-2);
 }
 
+.account-exp-value {
+    color: var(--color-ink-soft);
+}
+
+.account-exp-track {
+    height: var(--size-account-exp-track);
+    border-radius: var(--radius-pill);
+    background: var(--color-border-soft);
+    overflow: hidden;
+}
+
+.account-exp-fill {
+    height: 100%;
+    border-radius: inherit;
+    background: var(--color-primary);
+    transition: width 0.8s ease-out;
+}

--- a/src/components/menu/AccountScreen.tsx
+++ b/src/components/menu/AccountScreen.tsx
@@ -169,50 +169,21 @@ export function AccountScreen({
         statsContent = (
             <div className='account-stats-container-inner'>
                 <div className='solo-pregame-pb account-stats-centered'>
-                    <div
-                        className='solo-pregame-pb-stat'
-                        style={{
-                            flexDirection: 'column',
-                            alignItems: 'stretch',
-                            gap: '0.5rem',
-                        }}
-                    >
-                        <div
-                            style={{
-                                display: 'flex',
-                                justifyContent: 'space-between',
-                                alignItems: 'baseline',
-                            }}
-                        >
+                    <div className='solo-pregame-pb-stat account-exp-stat'>
+                        <div className='account-exp-header'>
                             <span className='solo-pregame-pb-label'>
-                                Lv. {expData.level}
+                                {uiText.levelLabel} {expData.level}
                             </span>
-                            <span
-                                className='solo-pregame-pb-label'
-                                style={{
-                                    fontSize: '0.8em',
-                                    color: 'var(--color-ink-soft)',
-                                }}
-                            >
+                            <span className='solo-pregame-pb-label account-exp-value'>
                                 {Math.floor(expData.progressInLevel)} /{' '}
-                                {expData.totalRequiredForNext} EXP
+                                {expData.totalRequiredForNext} {uiText.exp}
                             </span>
                         </div>
-                        <div
-                            style={{
-                                height: '6px',
-                                background: 'var(--color-border-soft)',
-                                borderRadius: '3px',
-                                overflow: 'hidden',
-                            }}
-                        >
+                        <div className='account-exp-track'>
                             <div
+                                className='account-exp-fill'
                                 style={{
-                                    height: '100%',
-                                    background: 'var(--color-primary)',
                                     width: `${expData.progressPercent}%`,
-                                    borderRadius: '3px',
-                                    transition: 'width 0.8s ease-out',
                                 }}
                             />
                         </div>

--- a/src/components/menu/MenuScreen.css
+++ b/src/components/menu/MenuScreen.css
@@ -71,6 +71,34 @@
     z-index: 3;
 }
 
+.menu-level-badge {
+    position: absolute;
+    left: 50%;
+    top: calc(25dvh + var(--space-6) + var(--space-4));
+    z-index: 4;
+    display: inline-flex;
+    align-items: baseline;
+    gap: var(--space-1);
+    min-height: var(--size-level-badge-height);
+    padding: var(--space-1) var(--space-3);
+    border: 2px solid var(--color-border-inverse-soft);
+    border-radius: var(--radius-pill);
+    background: var(--color-border-inverse-subtle);
+    color: var(--color-text-inverse);
+    font-family: var(--type-action-label-family);
+    font-size: var(--type-body-meta-size);
+    font-weight: var(--type-action-label-weight);
+    font-variant-numeric: tabular-nums;
+    line-height: var(--type-body-meta-line-height);
+    transform: translateX(-50%);
+}
+
+.menu-level-badge strong {
+    font-family: var(--type-metric-inline-family);
+    font-size: var(--type-metric-inline-size);
+    line-height: var(--type-metric-inline-line-height);
+}
+
 /* === Content below orb === */
 
 .menu-content {
@@ -171,17 +199,17 @@
 }
 
 @keyframes jelly-water-burst {
-    0% { 
+    0% {
         transform: scale(0.9);
-        box-shadow: 0 0 0 0 var(--color-primary-strong); 
+        box-shadow: 0 0 0 0 var(--color-primary-strong);
     }
-    30% { 
+    30% {
         transform: scale(1.15);
-        box-shadow: 0 0 0 15px transparent; 
+        box-shadow: 0 0 0 15px transparent;
     }
-    100% { 
+    100% {
         transform: scale(0.85);
-        box-shadow: 0 0 0 35px transparent; 
+        box-shadow: 0 0 0 35px transparent;
     }
 }
 

--- a/src/components/menu/MenuScreen.tsx
+++ b/src/components/menu/MenuScreen.tsx
@@ -27,6 +27,7 @@ type MenuScreenProps = {
     onOpenTutorial?: () => void;
     isGuest: boolean;
     needsTutorial?: boolean;
+    playerLevel: number | undefined;
 };
 
 export function MenuScreen({
@@ -41,6 +42,7 @@ export function MenuScreen({
     onOpenTutorial,
     isGuest,
     needsTutorial,
+    playerLevel,
 }: MenuScreenProps): JSX.Element {
     const [menuOpen, setMenuOpen] = useState(false);
     const [clickedMode, setClickedMode] = useState<string | undefined>(
@@ -209,6 +211,15 @@ export function MenuScreen({
                         />
                         <span>{uiText.titleTail}</span>
                     </h1>
+                    {playerLevel !== undefined ? (
+                        <div
+                            aria-label={`Level ${playerLevel}`}
+                            className='menu-level-badge'
+                        >
+                            <span>{uiText.levelLabel}</span>
+                            <strong>{playerLevel}</strong>
+                        </div>
+                    ) : undefined}
 
                     <div className='menu-content'>
                         {needsTutorial ? (

--- a/src/hooks/useLocalCpuGame.ts
+++ b/src/hooks/useLocalCpuGame.ts
@@ -6,7 +6,11 @@ import { applyPrimeSelection } from '../core/game';
 import type { RoomPlayer, RoomSnapshot } from '../core/multiplayer';
 import type { Prime } from '../core/primes';
 import { BLOB_REVEAL_TOTAL_MS } from '../core/timing';
-import { getDisplayPlayerName, playablePrimes } from '../lib/app-helpers';
+import {
+    getBattleExpGain,
+    getDisplayPlayerName,
+    playablePrimes,
+} from '../lib/app-helpers';
 import { processLocalBattleQueue } from '../lib/local-battle-queue';
 import {
     addPlayerToRoom,
@@ -25,6 +29,7 @@ type UseLocalCpuGameOptions = {
     playerName: string;
     screen: Screen;
     onScreenChange: (screen: Screen) => void;
+    onBattleFinish?: (experienceGain: number) => void;
 };
 
 type UseLocalCpuGameResult = {
@@ -48,6 +53,7 @@ type UseLocalCpuGameResult = {
 };
 
 export function useLocalCpuGame({
+    onBattleFinish,
     playerName,
     screen,
     onScreenChange,
@@ -63,6 +69,7 @@ export function useLocalCpuGame({
     const cpuTurnTimeoutRef = useRef<number | undefined>(undefined);
     const cpuRevealTimeoutRef = useRef<number | undefined>(undefined);
     const gameplayGenerationRef = useRef(0);
+    const recordedBattleExpRoomIdRef = useRef<string | undefined>(undefined);
     const previousCpuStageIndexRef = useRef<number | undefined>(undefined);
     // Use shared blob reveal state.
     const [isCpuBlobRevealActive, startBlobReveal, endBlobReveal] =
@@ -107,6 +114,45 @@ export function useLocalCpuGame({
         },
         []
     );
+
+    useEffect(() => {
+        if (multiplayerSnapshot?.status === 'playing') {
+            recordedBattleExpRoomIdRef.current = undefined;
+            return;
+        }
+
+        if (
+            multiplayerSnapshot?.status !== 'finished' ||
+            !multiplayerSnapshot.roomId ||
+            recordedBattleExpRoomIdRef.current === multiplayerSnapshot.roomId
+        ) {
+            return;
+        }
+
+        recordedBattleExpRoomIdRef.current = multiplayerSnapshot.roomId;
+
+        const localPlayer = multiplayerSnapshot.players.find(
+            (player) => player.id === playerId
+        );
+        const opponentPlayer = multiplayerSnapshot.players.find(
+            (player) => player.id !== playerId
+        );
+
+        if (!localPlayer) {
+            return;
+        }
+
+        const isWinner =
+            localPlayer.hp > 0 &&
+            opponentPlayer !== undefined &&
+            opponentPlayer.hp <= 0;
+        const isTie =
+            localPlayer.hp <= 0 &&
+            opponentPlayer !== undefined &&
+            opponentPlayer.hp <= 0;
+
+        onBattleFinish?.(getBattleExpGain(isWinner, isTie));
+    }, [multiplayerSnapshot, onBattleFinish, playerId]);
 
     useEffect(() => {
         const cpuStageIndex = cpuPlayer?.stageIndex;

--- a/src/hooks/useMultiplayerGame.ts
+++ b/src/hooks/useMultiplayerGame.ts
@@ -9,6 +9,7 @@ import type { Prime } from '../core/primes';
 import {
     createRoomId,
     detachPromise,
+    getBattleExpGain,
     getDisplayPlayerName,
     isPendingGuestJoin,
     playablePrimes,
@@ -230,6 +231,7 @@ type UseMultiplayerGameOptions = {
     playerName: string;
     screen: Screen;
     onScreenChange: (screen: Screen) => void;
+    onBattleFinish?: (experienceGain: number) => void;
 };
 
 type UseMultiplayerGameResult = {
@@ -257,6 +259,7 @@ type UseMultiplayerGameResult = {
 };
 
 export function useMultiplayerGame({
+    onBattleFinish,
     playerName,
     screen,
     onScreenChange,
@@ -787,6 +790,8 @@ export function useMultiplayerGame({
                 opponent !== undefined &&
                 opponent.hp <= 0;
 
+            onBattleFinish?.(getBattleExpGain(isWinner, isTie));
+
             if (supabaseAuthClient) {
                 detachPromise(
                     supabaseAuthClient.auth.getSession().then(({ data }) => {
@@ -808,7 +813,12 @@ export function useMultiplayerGame({
                 );
             }
         }
-    }, [multiplayer.snapshot, multiplayer.playerId, multiplayer.roomId]);
+    }, [
+        multiplayer.snapshot,
+        multiplayer.playerId,
+        multiplayer.roomId,
+        onBattleFinish,
+    ]);
 
     return {
         playablePrimes,

--- a/src/lib/app-helpers.ts
+++ b/src/lib/app-helpers.ts
@@ -5,11 +5,15 @@ import { PRIME_POOL } from '../core/primes';
 const playerNameStorageKey = 'atomize.playerName';
 const bestScoreStorageKey = 'atomize.bestScore';
 const bestMaxComboStorageKey = 'atomize.bestMaxCombo';
+const experienceStorageKey = 'atomize.experience';
 const tutorialCompleteStorageKey = 'atomize.tutorialComplete';
 const guestModeStorageKey = 'atomize.isGuestMode';
 const SOLO_SCORE_REDESIGN_AT = '2026-04-07T10:48:36.000Z';
 const HISTORIC_SOLO_SCORE_FACTOR = 0.5;
 const HISTORIC_SOLO_SCORE_CAP = 600;
+const battleWinExperience = 150;
+const battleTieExperience = 50;
+const battleLossExperience = 30;
 
 const guestSessionNumber = Math.floor(Math.random() * 999) + 1;
 
@@ -154,6 +158,53 @@ export function saveBestScore(score: number, maxCombo: number): boolean {
     }
 
     return isNewHighScore;
+}
+
+export function loadExperience(): number {
+    const experience = Number(
+        globalThis.localStorage.getItem(experienceStorageKey) ?? '0'
+    );
+
+    return Number.isFinite(experience) && experience > 0
+        ? Math.floor(experience)
+        : 0;
+}
+
+export function saveExperience(experience: number): number {
+    const normalizedExperience = Math.max(0, Math.floor(experience));
+
+    if (normalizedExperience > 0) {
+        globalThis.localStorage.setItem(
+            experienceStorageKey,
+            String(normalizedExperience)
+        );
+    } else {
+        globalThis.localStorage.removeItem(experienceStorageKey);
+    }
+
+    return normalizedExperience;
+}
+
+export function addExperience(experienceGain: number): number {
+    const normalizedGain = Math.max(0, Math.floor(experienceGain));
+
+    if (normalizedGain === 0) {
+        return loadExperience();
+    }
+
+    return saveExperience(loadExperience() + normalizedGain);
+}
+
+export function getSoloExpGain(score: number): number {
+    return Math.max(0, Math.floor(score / 10));
+}
+
+export function getBattleExpGain(isWinner: boolean, isTie: boolean): number {
+    if (isWinner) {
+        return battleWinExperience;
+    }
+
+    return isTie ? battleTieExperience : battleLossExperience;
 }
 
 export function isTutorialComplete(): boolean {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -18,8 +18,14 @@ import {
 } from './lib/app-helpers';
 
 function MenuPage(): JSX.Element {
-    const { session, isGuest, localCpuGame, multiplayerGame, navigateTo } =
-        useAppContext();
+    const {
+        session,
+        isGuest,
+        localCpuGame,
+        multiplayerGame,
+        navigateTo,
+        playerLevel,
+    } = useAppContext();
     const needsTutorial = !isTutorialComplete();
 
     const toastId = localCpuGame.isInRoom ? 0 : multiplayerGame.lobbyToast.id;
@@ -52,6 +58,7 @@ function MenuPage(): JSX.Element {
             onOpenTutorial={() => {
                 navigateTo('/tutorial');
             }}
+            playerLevel={playerLevel}
             toastId={toastId}
             toastMessage={toastMessage}
         />

--- a/src/theme.css
+++ b/src/theme.css
@@ -203,6 +203,8 @@
     --size-waiting-mark-min-width: 5.5rem;
     --size-waiting-mark-min-height: 1.62rem;
     --size-toast-width: 18rem;
+    --size-level-badge-height: 2rem;
+    --size-account-exp-track: 0.5rem;
 
     --opacity-disabled: 0.38;
     --opacity-muted: 0.5;


### PR DESCRIPTION
## Description

Closes #36.

Adds a minimal advancement path: local experience persistence, shared solo/battle XP helpers, auth sync that carries local XP into the leaderboard profile, and a main-menu level badge backed by the current player level.

## Comparison

**Before:** The main menu did not surface advancement, and guest/local XP had no persisted level to show.

**After:** The main menu shows the current level from local or authenticated experience, and solo/battle results award XP through the same path.