### PR TITLE
fix(input): use numeric desktop prime shortcuts

### DIFF
--- a/src/hooks/usePrimeKeyboardControls.ts
+++ b/src/hooks/usePrimeKeyboardControls.ts
@@ -1,10 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 
 import type { Prime } from '../core/primes';
-import {
-    desktopActionKeybinds,
-    getDesktopPrimeFromKey,
-} from '../lib/game-keybinds';
+import { desktopActionKeybinds } from '../lib/game-keybinds';
 
 type UsePrimeKeyboardControlsOptions = {
     canQueuePrime: boolean;
@@ -25,6 +22,10 @@ type UsePrimeKeyboardControlsResult = {
     handlePrimeTap: (prime: Prime) => void;
     handleSubmit: () => void;
 };
+
+function isPrimeDigitKey(key: string): boolean {
+    return key.length === 1 && key >= '1' && key <= '9';
+}
 
 export function usePrimeKeyboardControls({
     canQueuePrime,
@@ -86,17 +87,6 @@ export function usePrimeKeyboardControls({
     }
 
     function processFreshDigit(digit: string) {
-        if (digit === '4') {
-            const shortcutPrime = playablePrimes.find((prime) => prime === 23);
-
-            if (shortcutPrime !== undefined) {
-                clearBufferedPrimeInput();
-                onPrimeTap(shortcutPrime);
-            }
-
-            return;
-        }
-
         const matchingPrimes = playablePrimes.filter((prime) =>
             String(prime).startsWith(digit)
         );
@@ -147,6 +137,19 @@ export function usePrimeKeyboardControls({
         processFreshDigit(digit);
     }
 
+    function handlePrime23Shortcut() {
+        if (isInputDisabled || !canQueuePrime) {
+            return;
+        }
+
+        const shortcutPrime = playablePrimes.find((prime) => prime === 23);
+
+        if (shortcutPrime !== undefined) {
+            clearBufferedPrimeInput();
+            onPrimeTap(shortcutPrime);
+        }
+    }
+
     function handlePrimeTap(prime: Prime) {
         clearBufferedPrimeInput();
         onPrimeTap(prime);
@@ -187,7 +190,6 @@ export function usePrimeKeyboardControls({
     useEffect(() => {
         function handleWindowKeyDown(event: KeyboardEvent) {
             const { target } = event;
-            const normalizedKey = event.key.toLowerCase();
 
             if (
                 target instanceof HTMLElement &&
@@ -232,16 +234,13 @@ export function usePrimeKeyboardControls({
                 return;
             }
 
-            const directPrime = getDesktopPrimeFromKey(
-                playablePrimes,
-                normalizedKey
-            );
-
-            if (directPrime !== undefined) {
+            if (event.shiftKey && event.code === 'Digit2') {
                 event.preventDefault();
-                handlePrimeTap(directPrime);
+                handlePrime23Shortcut();
                 return;
             }
+
+            const normalizedKey = event.key.toLowerCase();
 
             if (normalizedKey === desktopActionKeybinds.backspace) {
                 if (
@@ -262,7 +261,7 @@ export function usePrimeKeyboardControls({
                 return;
             }
 
-            if (!/^[1-9]$/.test(event.key)) {
+            if (!isPrimeDigitKey(event.key)) {
                 return;
             }
 

--- a/src/lib/game-keybinds.ts
+++ b/src/lib/game-keybinds.ts
@@ -1,15 +1,15 @@
 import type { Prime } from '../core/primes';
 
 export const desktopPrimeKeybinds = [
-    'r',
-    't',
-    'y',
-    'f',
-    'g',
-    'h',
-    'v',
-    'b',
-    'n',
+    '2',
+    '3',
+    '5',
+    '7',
+    '11',
+    '13',
+    '17',
+    '19',
+    'Shift+2',
 ] as const;
 
 export const desktopActionKeybinds = {
@@ -28,19 +28,4 @@ export function getDesktopPrimeKeybind(
     }
 
     return desktopPrimeKeybinds[index];
-}
-
-export function getDesktopPrimeFromKey(
-    primes: readonly Prime[],
-    key: string
-): Prime | undefined {
-    const index = desktopPrimeKeybinds.indexOf(
-        key as (typeof desktopPrimeKeybinds)[number]
-    );
-
-    if (index === -1 || index >= primes.length) {
-        return undefined;
-    }
-
-    return primes[index];
 }


### PR DESCRIPTION
## Description

Closes #28.

Refines desktop prime entry to use numeric shortcuts instead of the old letter grid. The `23` prime now uses `Shift+2`; plain `4` is no longer a hidden shortcut.

## Comparison

**Before:** Desktop prime buttons displayed letter shortcuts (`R/T/Y/...`), and `4` queued `23`.

**After:** Prime buttons display numeric shortcuts (`2`, `3`, `5`, `7`, `11`, `13`, `17`, `19`, `Shift+2`), and `Shift+2` queues `23`.