### PR TITLE
fix(core): prevent NaN stage targets

### DIFF
--- a/godot/scripts/core/game.gd
+++ b/godot/scripts/core/game.gd
@@ -65,6 +65,10 @@ static func generate_stage(seed: String, stage_index: int) -> Dictionary:
 		var selectable_primes := (
 			get_fallback_stage_primes(max_prime_value) if available_primes.is_empty() else available_primes
 		)
+
+		if selectable_primes.is_empty():
+			break
+
 		var selected_prime := pick_stage_prime(selectable_primes, rng, large_repeat_prime)
 
 		factors.append(selected_prime)

--- a/scripts/godot/generate-core-fixtures.ts
+++ b/scripts/godot/generate-core-fixtures.ts
@@ -118,9 +118,36 @@ function createStageFixtures(): readonly StageFixture[] {
         Array.from({ length: 16 }, (_, stageIndex) => ({
             seed,
             stageIndex,
-            stage: generateStage(seed, stageIndex),
+            stage: assertValidStage(generateStage(seed, stageIndex)),
         }))
     );
+}
+
+function assertValidStage(stage: StageState): StageState {
+    if (
+        !Number.isSafeInteger(stage.targetValue) ||
+        stage.targetValue < 1 ||
+        stage.targetValue !==
+            stage.factors.reduce((product, factor) => product * factor, 1) ||
+        stage.remainingValue !== stage.targetValue ||
+        stage.remainingFactors.length !== stage.factors.length
+    ) {
+        throw new Error(
+            `Invalid generated stage ${stage.stageIndex}: ${JSON.stringify(stage)}`
+        );
+    }
+
+    return stage;
+}
+
+function assertStageGenerationInvariants() {
+    for (let seedIndex = 0; seedIndex < 32; seedIndex++) {
+        const seed = `stage-invariant:${seedIndex}`;
+
+        for (let stageIndex = 0; stageIndex < 128; stageIndex++) {
+            assertValidStage(generateStage(seed, stageIndex));
+        }
+    }
 }
 
 function createHashFixtures(): readonly HashFixture[] {
@@ -289,6 +316,8 @@ function pickWrongPrime(stage: StageState): Prime {
 
     return wrongPrime;
 }
+
+assertStageGenerationInvariants();
 
 const fixture = {
     generatedBy: 'scripts/godot/generate-core-fixtures.ts',

--- a/src/core/game.ts
+++ b/src/core/game.ts
@@ -195,6 +195,11 @@ export function generateStage(seed: string, stageIndex: number): StageState {
             availablePrimes.length === 0
                 ? getFallbackStagePrimes(maxPrimeValue)
                 : availablePrimes;
+
+        if (selectablePrimes.length === 0) {
+            break;
+        }
+
         const selectedPrime = pickStagePrime(
             selectablePrimes,
             rng,


### PR DESCRIPTION
## Description

Fixes #27.

Prevents stage generation from choosing a prime when both constrained and fallback prime lists are empty, avoiding an undefined multiplication path that can turn the next target into `NaN`. Mirrors the guard in Godot and adds fixture-generation invariants for finite stage targets.

## Comparison

**Before:** A rare impossible factor slot could fall through to an empty prime picker and allow the next target value to become `NaN`.

**After:** Stage generation keeps the already-valid target factors, and fixture generation asserts generated targets remain finite products.