### PR TITLE
fix(ui): improve responsive back button contrast

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -130,6 +130,13 @@ input::placeholder {
     color: var(--color-text-inverse);
 }
 
+@media (max-width: 480px), (min-width: 900px) {
+    .page-title-row .floating-back-button {
+        background: var(--color-surface-strong);
+        color: var(--color-primary);
+    }
+}
+
 .page-title {
     margin: var(--space-0);
     font-family: var(--type-action-label-family);


### PR DESCRIPTION
## Description

Fixes #26.

Responsive header back buttons now switch to a surface button with a primary icon at compact and desktop-wide breakpoints so the arrow remains visible when header and viewport surfaces change.

## Comparison

**Before:** The title-row back button used an inverse white icon at every viewport size, which could disappear when the responsive header surface matched it.

**After:** At `<=480px` and `>=900px`, the title-row back button uses the existing surface and primary color tokens for contrast. The existing white icon treatment remains for mid-size header layouts.