### PR TITLE
feat(mobile): polish battle feedback and native assets

### DIFF
--- a/godot/assets/icons/atom.svg.import
+++ b/godot/assets/icons/atom.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/back.svg.import
+++ b/godot/assets/icons/back.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/battle.svg.import
+++ b/godot/assets/icons/battle.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/bot.svg.import
+++ b/godot/assets/icons/bot.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/chevron-up.svg.import
+++ b/godot/assets/icons/chevron-up.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/cpu.svg.import
+++ b/godot/assets/icons/cpu.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/delete.svg.import
+++ b/godot/assets/icons/delete.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/guest.svg.import
+++ b/godot/assets/icons/guest.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/help.svg.import
+++ b/godot/assets/icons/help.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/menu.svg.import
+++ b/godot/assets/icons/menu.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/pause.svg.import
+++ b/godot/assets/icons/pause.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/play.svg.import
+++ b/godot/assets/icons/play.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/submit.svg.import
+++ b/godot/assets/icons/submit.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/timer.svg.import
+++ b/godot/assets/icons/timer.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/trophy.svg.import
+++ b/godot/assets/icons/trophy.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/assets/icons/users.svg.import
+++ b/godot/assets/icons/users.svg.import
@@ -38,6 +38,6 @@ process/hdr_as_srgb=false
 process/hdr_clamp_exposure=false
 process/size_limit=0
 detect_3d/compress_to=1
-svg/scale=1.0
+svg/scale=4.0
 editor/scale_with_editor_scale=false
 editor/convert_colors_with_editor_theme=false

--- a/godot/scripts/screens/main.gd
+++ b/godot/scripts/screens/main.gd
@@ -6203,14 +6203,12 @@ func _load_icon_image(kind: String, size: int) -> Image:
 	if path.is_empty():
 		return image
 
-	var file := FileAccess.open(path, FileAccess.READ)
-	if file == null:
+	var texture := ResourceLoader.load(path) as Texture2D
+	if texture == null:
 		return image
 
-	var scale: float = max(1.0, float(size) / 24.0)
-	if image.load_svg_from_buffer(file.get_buffer(file.get_length()), scale) != OK:
-		image.fill(Color.TRANSPARENT)
-		return image
+	image = texture.get_image()
+	image.convert(Image.FORMAT_RGBA8)
 
 	if image.get_width() != size or image.get_height() != size:
 		image.resize(size, size, Image.INTERPOLATE_LANCZOS)

--- a/godot/scripts/screens/main.gd
+++ b/godot/scripts/screens/main.gd
@@ -4866,7 +4866,8 @@ func _play_hp_hit(bar: ProgressBar, damage: int) -> void:
 
 	var severity := _attack_severity(damage)
 	_shake_control(bar, 6.0 + float(severity) * 3.0)
-	_shake_screen(2.0 + float(severity) * 1.5)
+	_shake_screen(4.0 + float(severity) * 2.0)
+	_spawn_battle_hit_flash(bar == player_hp_bar, severity)
 	_pulse_hp_bar_theme(bar, THEME_PROGRESS_DANGER, 0.42 + float(severity) * 0.06)
 	_pulse_label_color(_hp_label_for_bar(bar), COLOR_DANGER, _base_hp_color_for_bar(bar), 0.42)
 	_flash_control(bar, COLOR_DANGER, 0.56)
@@ -4966,14 +4967,48 @@ func _attack_severity(damage: int) -> int:
 	return 0
 
 func _shake_screen(distance: float) -> void:
+	if _prefers_reduced_motion():
+		return
+
 	var origin := position
 	var tween := _make_control_tween(self, "screen-shake")
 	tween.set_trans(Tween.TRANS_SINE)
 	tween.set_ease(Tween.EASE_OUT)
-	tween.tween_property(self, "position", origin + Vector2(-distance, 0), 0.018)
-	tween.tween_property(self, "position", origin + Vector2(distance * 0.72, 0), 0.018)
-	tween.tween_property(self, "position", origin + Vector2(-distance * 0.36, 0), 0.018)
-	tween.tween_property(self, "position", origin, 0.018)
+	tween.tween_property(self, "position", origin + Vector2(-distance, 0), 0.035)
+	tween.tween_property(self, "position", origin + Vector2(distance * 0.72, -distance * 0.28), 0.035)
+	tween.tween_property(self, "position", origin + Vector2(-distance * 0.48, distance * 0.24), 0.035)
+	tween.tween_property(self, "position", origin + Vector2(distance * 0.24, 0), 0.035)
+	tween.tween_property(self, "position", origin, 0.035)
+
+func _spawn_battle_hit_flash(player_hit: bool, severity: int) -> void:
+	var viewport_size := get_viewport_rect().size
+	var avatar: Control = target_blob_panel if player_hit else enemy_avatar_panel
+	var bar: ProgressBar = player_hp_bar if player_hit else enemy_hp_bar
+	var flash_top := viewport_size.y * (0.42 if player_hit else 0.0)
+	var flash_bottom := viewport_size.y * (1.0 if player_hit else 0.58)
+	if is_instance_valid(avatar) and is_instance_valid(bar):
+		flash_top = max(0.0, min(avatar.global_position.y, bar.global_position.y) - 24.0)
+		flash_bottom = min(
+			viewport_size.y,
+			max(avatar.global_position.y + avatar.size.y, bar.global_position.y + bar.size.y) + 24.0
+		)
+
+	var flash := ColorRect.new()
+	flash.name = "BattleHitFlash"
+	flash.color = COLOR_DANGER
+	flash.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	flash.z_index = 40
+	flash.position = Vector2(0, flash_top)
+	flash.size = Vector2(viewport_size.x, max(1.0, flash_bottom - flash_top))
+	flash.modulate = Color(1, 1, 1, 0.2 + float(severity) * 0.035)
+	add_child(flash)
+
+	var duration := 0.36 + float(severity) * 0.04
+	var tween := flash.create_tween().bind_node(flash)
+	tween.set_trans(Tween.TRANS_QUAD)
+	tween.set_ease(Tween.EASE_OUT)
+	tween.tween_property(flash, "modulate", Color(1, 1, 1, 0), duration)
+	tween.finished.connect(flash.queue_free)
 
 func _shake_control(control: Control, distance: float) -> void:
 	if not is_instance_valid(control):

--- a/godot/scripts/screens/main.gd
+++ b/godot/scripts/screens/main.gd
@@ -111,9 +111,11 @@ const SAFE_AREA_PAGE_PADDING := 24.0
 const SOLO_TARGET_SIZE := 272.0
 const SOLO_KEY_SIZE := 84.0
 const SOLO_KEY_GAP := 8.0
-const QUEUE_CHIP_SIZE := 26.0
-const QUEUE_CHIP_GAP := 2.0
-const QUEUE_SEPARATOR_WIDTH := 10.0
+const QUEUE_CHIP_SIZE := 28.0
+const QUEUE_CHIP_GAP := 4.0
+const QUEUE_SEPARATOR_WIDTH := 12.0
+const BATTLE_QUEUE_SLOT_HEIGHT := 48.0
+const BATTLE_QUEUE_CONTROLS_GAP := 12.0
 const SOLO_CONTROL_BOTTOM_MARGIN := 64.0
 const PAGE_HEADER_BOTTOM := 224.0
 const DIALOG_WIDTH := 304.0
@@ -150,6 +152,7 @@ const THEME_PANEL_BADGE_GOLD := "AtomPanelBadgeGold"
 const THEME_PANEL_BADGE_SURFACE := "AtomPanelBadgeSurface"
 const THEME_PANEL_READY_BADGE := "AtomPanelReadyBadge"
 const THEME_PANEL_PARTICLE_PRIMARY := "AtomPanelParticlePrimary"
+const THEME_PANEL_QUEUE_CHIP := "AtomPanelQueueChip"
 const THEME_PANEL_PARTICLE_SECONDARY := "AtomPanelParticleSecondary"
 const THEME_PANEL_PARTICLE_DANGER := "AtomPanelParticleDanger"
 const THEME_PANEL_PARTICLE_GOLD := "AtomPanelParticleGold"
@@ -2907,6 +2910,11 @@ func _build_battle_game_layout() -> void:
 	var safe_top := _safe_area_top()
 	var safe_left := _safe_area_left()
 	var safe_right := _safe_area_right()
+	var controls_height := (SOLO_KEY_SIZE * 3.0) + (SOLO_KEY_GAP * 2.0)
+	var controls_top := viewport_size.y - controls_height - SOLO_CONTROL_BOTTOM_MARGIN - _safe_area_bottom()
+	var queue_top := controls_top - BATTLE_QUEUE_SLOT_HEIGHT - BATTLE_QUEUE_CONTROLS_GAP
+	var player_hp_top := queue_top - 16.0
+	var player_name_top := player_hp_top - 28.0
 
 	var background := ColorRect.new()
 	background.color = COLOR_PAGE_BG
@@ -2959,32 +2967,37 @@ func _build_battle_game_layout() -> void:
 
 	battle_result_text = ""
 	result_label = _make_absolute_label("", 15, COLOR_SECONDARY, 800)
-	result_label.position = Vector2(0, 324.0 + safe_top)
+	result_label.position = Vector2(0, player_name_top - 28.0)
 	result_label.size = Vector2(viewport_size.x, 24)
 	add_child(result_label)
 
 	var player_name_text := "You" if tutorial_active else _battle_local_player_name()
 	var player_name := _make_absolute_label(player_name_text, 15, COLOR_PRIMARY_STRONG, 800)
 	player_name.horizontal_alignment = HORIZONTAL_ALIGNMENT_LEFT
-	player_name.position = Vector2(SAFE_AREA_EDGE_PADDING + safe_left, 384.0 + safe_top)
+	player_name.position = Vector2(SAFE_AREA_EDGE_PADDING + safe_left, player_name_top)
 	player_name.size = Vector2(160, 24)
 	add_child(player_name)
 
 	player_hp_label = _make_absolute_label("", 15, COLOR_PRIMARY_STRONG, 800)
 	player_hp_label.horizontal_alignment = HORIZONTAL_ALIGNMENT_RIGHT
-	player_hp_label.position = Vector2(viewport_size.x - 92.0 - safe_right, 384.0 + safe_top)
+	player_hp_label.position = Vector2(viewport_size.x - 92.0 - safe_right, player_name_top)
 	player_hp_label.size = Vector2(80, 24)
 	add_child(player_hp_label)
 
 	player_hp_bar = _make_hp_bar(COLOR_PRIMARY_STRONG)
-	player_hp_bar.position = Vector2(SAFE_AREA_EDGE_PADDING + safe_left, 408.0 + safe_top)
+	player_hp_bar.position = Vector2(SAFE_AREA_EDGE_PADDING + safe_left, player_hp_top)
 	player_hp_bar.size = Vector2(viewport_size.x - (SAFE_AREA_EDGE_PADDING * 2.0) - safe_left - safe_right, 10)
 	add_child(player_hp_bar)
 
+	var queue_slot := CenterContainer.new()
+	queue_slot.name = "BattleQueueSlot"
+	queue_slot.position = Vector2(24.0 + safe_left, queue_top)
+	queue_slot.size = Vector2(viewport_size.x - 48.0 - safe_left - safe_right, BATTLE_QUEUE_SLOT_HEIGHT)
+	queue_slot.mouse_filter = Control.MOUSE_FILTER_IGNORE
+	add_child(queue_slot)
+
 	queue_label = _make_queue_panel()
-	queue_label.position = Vector2(24.0 + safe_left, 436.0 + safe_top)
-	queue_label.size = Vector2(viewport_size.x - 48.0 - safe_left - safe_right, 48)
-	add_child(queue_label)
+	queue_slot.add_child(queue_label)
 
 	var controls := _build_prime_keypad_controls(_queue_battle_prime, _backspace_battle_queue, _submit_battle_queue)
 	_animate_game_layout_entry(target_blob, controls)
@@ -4133,6 +4146,7 @@ func _make_app_theme() -> Theme:
 	_add_panel_theme(app_theme, THEME_PANEL_BADGE_SURFACE, "Panel", _make_button_style(COLOR_SURFACE))
 	_add_panel_theme(app_theme, THEME_PANEL_READY_BADGE, "Panel", _make_pixel_box_style(COLOR_SURFACE, COLOR_PRIMARY, PIXEL_BORDER, RADIUS_PILL, true))
 	_add_panel_theme(app_theme, THEME_PANEL_PARTICLE_PRIMARY, "Panel", _make_pixel_box_style(COLOR_PRIMARY_STRONG, Color.TRANSPARENT, 0, RADIUS_PILL))
+	_add_panel_theme(app_theme, THEME_PANEL_QUEUE_CHIP, "Panel", _make_pixel_circle_style(COLOR_PRIMARY_STRONG, Color.TRANSPARENT, 0))
 	_add_panel_theme(app_theme, THEME_PANEL_PARTICLE_SECONDARY, "Panel", _make_pixel_box_style(COLOR_SECONDARY, Color.TRANSPARENT, 0, RADIUS_PILL))
 	_add_panel_theme(app_theme, THEME_PANEL_PARTICLE_DANGER, "Panel", _make_pixel_box_style(COLOR_DANGER, Color.TRANSPARENT, 0, RADIUS_PILL))
 	_add_panel_theme(app_theme, THEME_PANEL_PARTICLE_GOLD, "Panel", _make_pixel_box_style(COLOR_GOLD, Color.TRANSPARENT, 0, RADIUS_PILL))
@@ -6479,10 +6493,13 @@ func _render_queue_panel(numbers: Array) -> void:
 
 func _make_queue_chip(text: String, is_pending: bool) -> Panel:
 	var chip := Panel.new()
+	chip.name = "QueueChip"
 	chip.custom_minimum_size = Vector2(QUEUE_CHIP_SIZE, QUEUE_CHIP_SIZE)
+	chip.size_flags_horizontal = Control.SIZE_SHRINK_CENTER
+	chip.size_flags_vertical = Control.SIZE_SHRINK_CENTER
 	chip.mouse_filter = Control.MOUSE_FILTER_IGNORE
 	chip.modulate.a = 0.5 if is_pending else 1.0
-	_apply_panel_theme(chip, THEME_PANEL_PARTICLE_PRIMARY)
+	_apply_panel_theme(chip, THEME_PANEL_QUEUE_CHIP)
 
 	var label := _make_absolute_label(text, 12, COLOR_TEXT_INVERSE, 700)
 	label.set_anchors_and_offsets_preset(Control.PRESET_FULL_RECT)

--- a/godot/tests/run_screen_smoke.gd
+++ b/godot/tests/run_screen_smoke.gd
@@ -160,7 +160,7 @@ func _validate_attack_vfx(main_scene: Node, failures: Array[String]) -> void:
 		failures.append("impact shockwave is visible before bullet impact")
 
 func _validate_battle_emotion_vfx(main_scene: Node, failures: Array[String]) -> void:
-	for method_name in ["_spawn_heal_stream", "_spawn_fault_shards", "_spawn_perfect_halo"]:
+	for method_name in ["_spawn_heal_stream", "_spawn_fault_shards", "_spawn_perfect_halo", "_spawn_battle_hit_flash"]:
 		if not main_scene.has_method(method_name):
 			failures.append("missing battle emotion VFX method %s" % method_name)
 			return
@@ -168,8 +168,9 @@ func _validate_battle_emotion_vfx(main_scene: Node, failures: Array[String]) -> 
 	main_scene.call("_spawn_heal_stream", Vector2(120, 420), Vector2(250, 96), 12)
 	main_scene.call("_spawn_fault_shards", Vector2(180, 360), 6)
 	main_scene.call("_spawn_perfect_halo", Vector2(220, 300))
+	main_scene.call("_spawn_battle_hit_flash", true, 1)
 
-	for node_name in ["HealPulse", "HealMote", "FaultShard", "PerfectHalo", "PerfectOrbitMote"]:
+	for node_name in ["HealPulse", "HealMote", "FaultShard", "PerfectHalo", "PerfectOrbitMote", "BattleHitFlash"]:
 		if main_scene.find_child(node_name, true, false) == null:
 			failures.append("battle emotion VFX did not spawn %s" % node_name)
 

--- a/godot/tests/run_screen_smoke.gd
+++ b/godot/tests/run_screen_smoke.gd
@@ -3,6 +3,7 @@ extends SceneTree
 const MAIN_SCENE := preload("res://scenes/Main.tscn")
 const Game := preload("res://scripts/core/game.gd")
 const SCREEN_ARG_PREFIX := "--atomize-screen="
+const QUEUE_CHIP_MIN_RADIUS := 14.0
 
 func _init() -> void:
 	call_deferred("_run")
@@ -60,6 +61,7 @@ func _validate_screen(main_scene: Node, screen_name: String) -> Array[String]:
 	if label == "battle-game":
 		_validate_attack_vfx(main_scene, failures)
 		_validate_battle_emotion_vfx(main_scene, failures)
+		_validate_battle_queue_layout(main_scene, failures)
 
 	return failures
 
@@ -173,6 +175,31 @@ func _validate_battle_emotion_vfx(main_scene: Node, failures: Array[String]) -> 
 	for node_name in ["HealPulse", "HealMote", "FaultShard", "PerfectHalo", "PerfectOrbitMote", "BattleHitFlash"]:
 		if main_scene.find_child(node_name, true, false) == null:
 			failures.append("battle emotion VFX did not spawn %s" % node_name)
+
+func _validate_battle_queue_layout(main_scene: Node, failures: Array[String]) -> void:
+	var queue_slot := main_scene.find_child("BattleQueueSlot", true, false) as CenterContainer
+	var controls := main_scene.find_child("PrimeControls", true, false) as Control
+	if queue_slot == null:
+		failures.append("battle queue is missing its reserved slot")
+		return
+	if controls == null:
+		failures.append("battle queue could not validate keypad spacing")
+		return
+	if queue_slot.position.y + queue_slot.size.y > controls.position.y:
+		failures.append("battle queue overlaps the keypad controls")
+
+	main_scene.call("_render_queue_panel", [2, 3, 5])
+	var chip := main_scene.find_child("QueueChip", true, false) as Panel
+	if chip == null:
+		failures.append("battle queue did not render a queue chip")
+		return
+	if chip.custom_minimum_size.x != chip.custom_minimum_size.y:
+		failures.append("battle queue chip is not square")
+	if chip.size_flags_vertical != Control.SIZE_SHRINK_CENTER:
+		failures.append("battle queue chip can stretch out of its round shape")
+	var chip_style := chip.get_theme_stylebox("panel") as StyleBoxFlat
+	if chip_style == null or chip_style.corner_radius_top_left < int(QUEUE_CHIP_MIN_RADIUS):
+		failures.append("battle queue chip is not rounded")
 
 func _expect_minimum_controls(
 	main_scene: Node,

--- a/scripts/godot/ios-run-device.sh
+++ b/scripts/godot/ios-run-device.sh
@@ -20,10 +20,44 @@ detect_device_id() {
         return 1
     fi
 
-    local device_id
-    device_id="$(
-        plutil -extract result.devices.0.hardwareProperties.udid raw -o - "$devices_json" 2>/dev/null || true
+    local device_count
+    device_count="$(
+        plutil -extract result.devices raw -o - "$devices_json" 2>/dev/null || true
     )"
+    if [[ ! "$device_count" =~ ^[0-9]+$ ]]; then
+        rm -f "$devices_json"
+        return 1
+    fi
+
+    local device_id=""
+    local device_index
+    for ((device_index = 0; device_index < device_count; device_index++)); do
+        local tunnel_state
+        tunnel_state="$(
+            plutil \
+                -extract "result.devices.$device_index.connectionProperties.tunnelState" \
+                raw \
+                -o - \
+                "$devices_json" 2>/dev/null || true
+        )"
+
+        if [[ "$tunnel_state" != "connected" ]]; then
+            continue
+        fi
+
+        device_id="$(
+            plutil \
+                -extract "result.devices.$device_index.hardwareProperties.udid" \
+                raw \
+                -o - \
+                "$devices_json" 2>/dev/null || true
+        )"
+
+        if [[ -n "$device_id" ]]; then
+            break
+        fi
+    done
+
     rm -f "$devices_json"
 
     [[ -n "$device_id" ]] && printf '%s\n' "$device_id"

--- a/src/components/game/MultiplayerGameScreen.css
+++ b/src/components/game/MultiplayerGameScreen.css
@@ -37,6 +37,7 @@
 }
 
 .multiplayer-board {
+    --battle-hit-duration: 0s;
     position: relative;
     flex: 1;
     min-height: 0;
@@ -47,6 +48,78 @@
     overflow: visible;
     width: min(100%, 32rem);
     margin-inline: auto;
+}
+
+@keyframes multiplayer-board-hit-shake {
+    0%,
+    100% {
+        transform: translate(0);
+    }
+
+    20% {
+        transform: translate(-4px, 0);
+    }
+
+    42% {
+        transform: translate(4px, -4px);
+    }
+
+    64% {
+        transform: translate(-4px, 4px);
+    }
+
+    82% {
+        transform: translate(4px, 0);
+    }
+}
+
+@keyframes multiplayer-board-hit-flash {
+    0% {
+        opacity: var(--opacity-subtle);
+    }
+
+    45% {
+        opacity: var(--opacity-soft);
+    }
+
+    100% {
+        opacity: 0;
+    }
+}
+
+.multiplayer-board--self-hit,
+.multiplayer-board--enemy-hit {
+    animation: multiplayer-board-hit-shake var(--battle-hit-duration)
+        cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.multiplayer-board--self-hit::after,
+.multiplayer-board--enemy-hit::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 4;
+    border-radius: var(--radius-panel);
+    background: var(--color-danger);
+    opacity: 0;
+    pointer-events: none;
+    animation: multiplayer-board-hit-flash
+        calc(var(--battle-hit-duration) + 0.12s) ease-out;
+}
+
+.multiplayer-board--self-hit::after {
+    clip-path: inset(42% 0 0);
+}
+
+.multiplayer-board--enemy-hit::after {
+    clip-path: inset(0 0 42%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .multiplayer-board--self-hit,
+    .multiplayer-board--enemy-hit {
+        animation: none;
+    }
 }
 
 .multiplayer-column {

--- a/src/components/game/MultiplayerGameScreen.tsx
+++ b/src/components/game/MultiplayerGameScreen.tsx
@@ -193,7 +193,30 @@ export function MultiplayerGameScreen({
     return (
         <main className='app-shell fullscreen-shell'>
             <section className='screen game-screen multiplayer-game-screen'>
-                <section className='multiplayer-board' ref={battle.overlayRef}>
+                <section
+                    className={[
+                        'multiplayer-board',
+                        battle.hpImpacts.self?.hit
+                            ? 'multiplayer-board--self-hit'
+                            : '',
+                        battle.hpImpacts.enemy?.hit
+                            ? 'multiplayer-board--enemy-hit'
+                            : '',
+                    ]
+                        .filter(Boolean)
+                        .join(' ')}
+                    ref={battle.overlayRef}
+                    style={
+                        {
+                            '--battle-hit-duration': `${
+                                Math.max(
+                                    battle.hpImpacts.self?.hit?.durationMs ?? 0,
+                                    battle.hpImpacts.enemy?.hit?.durationMs ?? 0
+                                ) / 1000
+                            }s`,
+                        } as CSSProperties
+                    }
+                >
                     <BattleHpBar
                         damagePops={battle.damagePops.filter(
                             (damagePop) => damagePop.side === 'enemy'


### PR DESCRIPTION
## Description

- select the connected physical Apple device when launching the Godot iOS export
- load exported Godot icon textures at a higher import scale so native builds retain their icons
- strengthen web and Godot battle hit feedback with directional red flashes and screen shake while respecting reduced-motion preferences
- reserve a stable battle queue slot, keep it clear of the keypad, and render queued blobs as circles
- extend Godot smoke coverage for the battle hit flash and queue layout

## Comparison

**Before:** iOS launch could select an unavailable device, exported icons could disappear, battle damage feedback was easy to miss, and the Godot queue could shift into the controls with stretched chips.

**After:** iOS uses a connected device, icons survive export, both clients provide stronger damage feedback, and the Godot queue occupies reserved space with consistently round blobs.
