### PR TITLE
chore(dev): make local Supabase reproducible

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ VITE_SUPABASE_URL=your-project-url
 VITE_SUPABASE_ANON_KEY=your-anon-key
 ```
 
+### Local Supabase
+
+The tracked `supabase/config.toml` uses PostgreSQL 17, anonymous sign-in, Auth,
+Storage, and Realtime to match Atomize's hosted project without storing a token
+or project credential. Start the local backend, reset it from tracked
+migrations, and regenerate database types with:
+
+```bash
+bun run backend:start
+bun run backend:reset
+bun run backend:types
+```
+
+Maintainers can link the checkout to the hosted Atomize project after logging
+in with the Supabase CLI:
+
+```bash
+bunx supabase@2.109.1 link --project-ref <project-ref>
+bun run backend:types:remote
+```
+
+Link state and local environment files remain ignored under `supabase/.temp`
+and `supabase/.env*.local`. Never commit a service-role key.
+
 ## Godot mobile port
 
 The parallel Godot iOS/Android port lives in `godot/`. The Vite app remains the

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ bun run backend:types:remote
 
 Link state and local environment files remain ignored under `supabase/.temp`
 and `supabase/.env*.local`. Never commit a service-role key.
+The CLI exposes its development ports on the host, so use this stack only on a
+trusted network with the host firewall enabled and stop it when finished.
 
 ## Godot mobile port
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,11 @@
         "godot:smoke": "bun run scripts/godot/import-project.ts && bun run scripts/godot/run-screen-smoke.ts",
         "godot:menu-flow": "bun run scripts/godot/import-project.ts && bun run scripts/godot/run-menu-flow.ts",
         "godot:auth-live": "bun run scripts/godot/import-project.ts && bun run scripts/godot/run-supabase-auth-live.ts",
+        "backend:start": "bunx supabase@2.109.1 start",
+        "backend:stop": "bunx supabase@2.109.1 stop",
+        "backend:reset": "bunx supabase@2.109.1 db reset",
+        "backend:types": "bunx supabase@2.109.1 gen types typescript --local > src/lib/database.types.ts",
+        "backend:types:remote": "bunx supabase@2.109.1 gen types typescript --linked > src/lib/database.types.ts",
         "ios": "scripts/godot/ios.sh",
         "ios:export": "bun run scripts/godot/export-mobile.ts ios",
         "android": "bun run scripts/godot/export-mobile.ts android"

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
         "godot:auth-live": "bun run scripts/godot/import-project.ts && bun run scripts/godot/run-supabase-auth-live.ts",
         "backend:start": "bunx supabase@2.109.1 start",
         "backend:stop": "bunx supabase@2.109.1 stop",
-        "backend:reset": "bunx supabase@2.109.1 db reset",
+        "backend:reset": "bunx supabase@2.109.1 db reset --local",
         "backend:types": "bunx supabase@2.109.1 gen types typescript --local > src/lib/database.types.ts",
         "backend:types:remote": "bunx supabase@2.109.1 gen types typescript --linked > src/lib/database.types.ts",
         "ios": "scripts/godot/ios.sh",

--- a/src/lib/database.types.ts
+++ b/src/lib/database.types.ts
@@ -7,76 +7,123 @@ export type Json =
     | Json[];
 
 export type Database = {
-    /* Allows to automatically instantiate createClient with right options
-     instead of createClient<Database, { PostgrestVersion: 'XX' }>(URL, KEY) */
-    __InternalSupabase: {
-        PostgrestVersion: '14.4';
+    graphql_public: {
+        Tables: {
+            [_ in never]: never;
+        };
+        Views: {
+            [_ in never]: never;
+        };
+        Functions: {
+            graphql: {
+                Args: {
+                    extensions?: Json;
+                    operationName?: string;
+                    query?: string;
+                    variables?: Json;
+                };
+                Returns: Json;
+            };
+        };
+        Enums: {
+            [_ in never]: never;
+        };
+        CompositeTypes: {
+            [_ in never]: never;
+        };
     };
     public: {
         Tables: {
             combo_leaderboard: {
                 Row: {
+                    experience: number;
                     games_played: number;
                     high_score: number;
                     losses: number;
                     max_combo: number;
                     player_name: string;
                     ties: number;
-                    updated_at: string | null;
+                    updated_at: string;
                     user_id: string;
                     wins: number;
-                    experience: number;
                 };
                 Insert: {
+                    experience?: number;
                     games_played?: number;
                     high_score?: number;
                     losses?: number;
                     max_combo?: number;
                     player_name: string;
                     ties?: number;
-                    updated_at?: string | null;
+                    updated_at?: string;
                     user_id: string;
                     wins?: number;
-                    experience?: number;
                 };
                 Update: {
+                    experience?: number;
                     games_played?: number;
                     high_score?: number;
                     losses?: number;
                     max_combo?: number;
                     player_name?: string;
                     ties?: number;
-                    updated_at?: string | null;
+                    updated_at?: string;
                     user_id?: string;
                     wins?: number;
-                    experience?: number;
                 };
                 Relationships: [];
             };
             friendships: {
                 Row: {
-                    id: string;
-                    created_at: string | null;
+                    created_at: string;
                     friend_id: string;
+                    id: string;
                     user_id: string;
                 };
                 Insert: {
-                    id?: string;
-                    created_at?: string | null;
+                    created_at?: string;
                     friend_id: string;
+                    id?: string;
                     user_id: string;
                 };
                 Update: {
-                    id?: string;
-                    created_at?: string | null;
+                    created_at?: string;
                     friend_id?: string;
+                    id?: string;
                     user_id?: string;
                 };
                 Relationships: [];
             };
         };
-        Views: Record<string, never>;
+        Views: {
+            [_ in never]: never;
+        };
         Functions: {
+            add_solo_exp: {
+                Args: { p_exp_gain: number; p_user_id: string };
+                Returns: undefined;
+            };
+            claim_player_name: {
+                Args: { p_player_name: string };
+                Returns: {
+                    experience: number;
+                    games_played: number;
+                    high_score: number;
+                    losses: number;
+                    max_combo: number;
+                    player_name: string;
+                    ties: number;
+                    updated_at: string;
+                    user_id: string;
+                    wins: number;
+                };
+                SetofOptions: {
+                    from: '*';
+                    to: 'combo_leaderboard';
+                    isOneToOne: true;
+                    isSetofReturn: false;
+                };
+            };
             record_match_result: {
                 Args: {
                     p_is_tie: boolean;
@@ -85,16 +132,34 @@ export type Database = {
                 };
                 Returns: undefined;
             };
-            add_solo_exp: {
-                Args: {
-                    p_user_id: string;
-                    p_exp_gain: number;
+            submit_solo_score: {
+                Args: { p_max_combo?: number; p_score: number };
+                Returns: {
+                    experience: number;
+                    games_played: number;
+                    high_score: number;
+                    losses: number;
+                    max_combo: number;
+                    player_name: string;
+                    ties: number;
+                    updated_at: string;
+                    user_id: string;
+                    wins: number;
                 };
-                Returns: undefined;
+                SetofOptions: {
+                    from: '*';
+                    to: 'combo_leaderboard';
+                    isOneToOne: true;
+                    isSetofReturn: false;
+                };
             };
         };
-        Enums: Record<string, never>;
-        CompositeTypes: Record<string, never>;
+        Enums: {
+            [_ in never]: never;
+        };
+        CompositeTypes: {
+            [_ in never]: never;
+        };
     };
 };
 
@@ -109,12 +174,12 @@ export type Tables<
     DefaultSchemaTableNameOrOptions extends
         | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
         | { schema: keyof DatabaseWithoutInternals },
-    TableName extends DefaultSchemaTableNameOrOptions extends {
+    TableName extends (DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
         ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
               DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
-        : never = never,
+        : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
@@ -138,11 +203,11 @@ export type TablesInsert<
     DefaultSchemaTableNameOrOptions extends
         | keyof DefaultSchema['Tables']
         | { schema: keyof DatabaseWithoutInternals },
-    TableName extends DefaultSchemaTableNameOrOptions extends {
+    TableName extends (DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
         ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-        : never = never,
+        : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
@@ -163,11 +228,11 @@ export type TablesUpdate<
     DefaultSchemaTableNameOrOptions extends
         | keyof DefaultSchema['Tables']
         | { schema: keyof DatabaseWithoutInternals },
-    TableName extends DefaultSchemaTableNameOrOptions extends {
+    TableName extends (DefaultSchemaTableNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
         ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
-        : never = never,
+        : never) = never,
 > = DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
@@ -188,11 +253,11 @@ export type Enums<
     DefaultSchemaEnumNameOrOptions extends
         | keyof DefaultSchema['Enums']
         | { schema: keyof DatabaseWithoutInternals },
-    EnumName extends DefaultSchemaEnumNameOrOptions extends {
+    EnumName extends (DefaultSchemaEnumNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
         ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
-        : string = never,
+        : never) = never,
 > = DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
@@ -205,11 +270,11 @@ export type CompositeTypes<
     PublicCompositeTypeNameOrOptions extends
         | keyof DefaultSchema['CompositeTypes']
         | { schema: keyof DatabaseWithoutInternals },
-    CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    CompositeTypeName extends (PublicCompositeTypeNameOrOptions extends {
         schema: keyof DatabaseWithoutInternals;
     }
         ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
-        : string = never,
+        : never) = never,
 > = PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals;
 }
@@ -219,6 +284,9 @@ export type CompositeTypes<
       : never;
 
 export const Constants = {
+    graphql_public: {
+        Enums: {},
+    },
     public: {
         Enums: {},
     },

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,8 @@
+# Supabase
+.branches
+.temp
+
+# dotenvx
+.env.keys
+.env.local
+.env.*.local

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,414 @@
+# For detailed configuration reference documentation, visit:
+# https://supabase.com/docs/guides/local-development/cli/config
+# A string used to distinguish different Supabase projects on the same host. Defaults to the
+# working directory name when running `supabase init`.
+project_id = "atomize"
+
+[api]
+enabled = true
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. `public` and `graphql_public` schemas are included by default.
+schemas = ["public", "graphql_public"]
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["public", "extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+# Controls whether new tables, views, sequences and functions created in the `public` schema by
+# `postgres` are reachable through the Data API roles (`anon`, `authenticated`, `service_role`)
+# without explicit GRANTs. When unset, new entities are NOT auto-exposed, matching the new cloud
+# default. Set to `true` to keep the legacy behaviour of auto-exposing new entities; this is
+# deprecated and the field is removed on 2026-10-30 once the always-revoked behaviour is permanent.
+# auto_expose_new_tables = true
+
+[api.tls]
+# Enable HTTPS endpoints locally using a self-signed certificate.
+enabled = false
+# Paths to self-signed certificate pair.
+# cert_path = "../certs/my-cert.pem"
+# key_path = "../certs/my-key.pem"
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# Port used by db diff command to initialize the shadow database.
+shadow_port = 54320
+# Maximum amount of time to wait for health check when starting the local database.
+health_timeout = "2m"
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 17
+
+[db.pooler]
+enabled = false
+# Port to use for the local connection pooler.
+port = 54329
+# Specifies when a server connection can be reused by other clients.
+# Configure one of the supported pooler modes: `transaction`, `session`.
+pool_mode = "transaction"
+# How many server connections to allow per user/database pair.
+default_pool_size = 20
+# Maximum number of client connections allowed.
+max_client_conn = 100
+
+# [db.vault]
+# secret_key = "env(SECRET_VALUE)"
+
+[db.migrations]
+# If disabled, migrations will be skipped during a db push or reset.
+enabled = true
+# Specifies an ordered list of schema files, directories, or glob patterns that describe your database.
+# Supports paths relative to supabase directory: "./schemas/*.sql", "./database".
+schema_paths = []
+
+[db.seed]
+# If enabled, seeds the database after migrations during a db reset.
+enabled = true
+# Specifies an ordered list of seed files to load during db reset.
+# Supports glob patterns relative to supabase directory: "./seeds/*.sql"
+sql_paths = ["./seed.sql"]
+
+[db.network_restrictions]
+# Enable management of network restrictions.
+enabled = false
+# List of IPv4 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv4 connections. Set empty array to block all IPs.
+allowed_cidrs = ["0.0.0.0/0"]
+# List of IPv6 CIDR blocks allowed to connect to the database.
+# Defaults to allow all IPv6 connections. Set empty array to block all IPs.
+allowed_cidrs_v6 = ["::/0"]
+
+# Uncomment to reject non-secure connections to the database.
+# [db.ssl_enforcement]
+# enabled = true
+
+[realtime]
+enabled = true
+# Bind realtime via either IPv4 or IPv6. (default: IPv4)
+# ip_version = "IPv6"
+# The maximum length in bytes of HTTP request headers. (default: 4096)
+# max_header_length = 4096
+
+[studio]
+enabled = true
+# Port to use for Supabase Studio.
+port = 54323
+# External URL of the API server that frontend connects to.
+api_url = "http://127.0.0.1"
+# OpenAI API Key to use for Supabase AI in the Supabase Studio.
+openai_api_key = "env(OPENAI_API_KEY)"
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[local_smtp]
+enabled = true
+# Port to use for the email testing server web interface.
+port = 54324
+# Uncomment to expose additional ports for testing user applications that send emails.
+# smtp_port = 54325
+# pop3_port = 54326
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+[storage]
+enabled = true
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+# Uncomment to configure local storage buckets
+# [storage.buckets.images]
+# public = false
+# file_size_limit = "50MiB"
+# allowed_mime_types = ["image/png", "image/jpeg"]
+# objects_path = "./images"
+
+# Allow connections via S3 compatible clients
+[storage.s3_protocol]
+enabled = true
+
+# Image transformation API is available to Supabase Pro plan.
+# [storage.image_transformation]
+# enabled = true
+
+# Store analytical data in S3 for running ETL jobs over Iceberg Catalog
+# This feature is only available on the hosted platform.
+[storage.analytics]
+enabled = false
+max_namespaces = 5
+max_tables = 10
+max_catalogs = 2
+
+# Analytics Buckets is available to Supabase Pro plan.
+# [storage.analytics.buckets.my-warehouse]
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+max_buckets = 10
+max_indexes = 5
+
+# Vector Buckets is available to Supabase Pro plan.
+# [storage.vector.buckets.documents-openai]
+
+[auth]
+enabled = true
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://127.0.0.1:5173"
+# The public URL that Auth serves on. Defaults to the API external URL with `/auth/v1` appended.
+# external_url = ""
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["http://localhost:5173"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
+jwt_expiry = 3600
+# JWT issuer URL. If not set, defaults to auth.external_url.
+# jwt_issuer = ""
+# Path to JWT signing key. DO NOT commit your signing keys file to git.
+# signing_keys_path = "./signing_keys.json"
+# If disabled, the refresh token will never expire.
+enable_refresh_token_rotation = true
+# Allows refresh tokens to be reused after expiry, up to the specified interval in seconds.
+# Requires enable_refresh_token_rotation = true.
+refresh_token_reuse_interval = 10
+# Allow/disallow new user signups to your project.
+enable_signup = true
+# Allow/disallow anonymous sign-ins to your project.
+enable_anonymous_sign_ins = true
+# Allow/disallow testing manual linking of accounts
+enable_manual_linking = false
+# Passwords shorter than this value will be rejected as weak. Minimum 6, recommended 8 or more.
+minimum_password_length = 6
+# Passwords that do not meet the following requirements will be rejected as weak. Supported values
+# are: `letters_digits`, `lower_upper_letters_digits`, `lower_upper_letters_digits_symbols`
+password_requirements = ""
+
+# Configure passkey sign-ins.
+# [auth.passkey]
+# enabled = false
+
+# Configure WebAuthn relying party settings (required when passkey is enabled).
+# [auth.webauthn]
+# rp_display_name = "Supabase"
+# rp_id = "localhost"
+# rp_origins = ["http://127.0.0.1:3000"]
+
+[auth.rate_limit]
+# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
+email_sent = 2
+# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+sms_sent = 30
+# Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
+anonymous_users = 30
+# Number of sessions that can be refreshed in a 5 minute interval per IP address.
+token_refresh = 150
+# Number of sign up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users).
+sign_in_sign_ups = 30
+# Number of OTP / Magic link verifications that can be made in a 5 minute interval per IP address.
+token_verifications = 30
+# Number of Web3 logins that can be made in a 5 minute interval per IP address.
+web3 = 30
+
+# Configure one of the supported captcha providers: `hcaptcha`, `turnstile`.
+# [auth.captcha]
+# enabled = true
+# provider = "hcaptcha"
+# secret = ""
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = true
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = false
+# If enabled, users will need to reauthenticate or have logged in recently to change their password.
+secure_password_change = false
+# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
+max_frequency = "1s"
+# Number of characters used in the email OTP.
+otp_length = 6
+# Number of seconds before the email OTP expires (defaults to 1 hour).
+otp_expiry = 3600
+
+# Use a production-ready SMTP server
+# [auth.email.smtp]
+# enabled = true
+# host = "smtp.sendgrid.net"
+# port = 587
+# user = "apikey"
+# pass = "env(SENDGRID_API_KEY)"
+# admin_email = "admin@email.com"
+# sender_name = "Admin"
+
+# Uncomment to customize email template
+# [auth.email.template.invite]
+# subject = "You have been invited"
+# content_path = "./supabase/templates/invite.html"
+
+# Uncomment to customize notification email template
+# [auth.email.notification.password_changed]
+# enabled = true
+# subject = "Your password has been changed"
+# content_path = "./templates/password_changed_notification.html"
+
+[auth.sms]
+# Allow/disallow new user signups via SMS to your project.
+enable_signup = false
+# If enabled, users need to confirm their phone number before signing in.
+enable_confirmations = false
+# Template for sending OTP to users
+template = "Your code is {{ `{{ .Code }}` }}"
+# Controls the minimum amount of time that must pass before sending another sms otp.
+max_frequency = "5s"
+
+# Use pre-defined map of phone number to OTP for testing.
+# [auth.sms.test_otp]
+# 4152127777 = "123456"
+
+# Configure logged in session timeouts.
+# [auth.sessions]
+# Force log out after the specified duration.
+# timebox = "24h"
+# Force log out if the user has been inactive longer than the specified duration.
+# inactivity_timeout = "8h"
+
+# This hook runs before a new user is created and allows developers to reject the request based on the incoming user object.
+# [auth.hook.before_user_created]
+# enabled = true
+# uri = "pg-functions://postgres/auth/before-user-created-hook"
+
+# This hook runs before a token is issued and allows you to add additional claims based on the authentication method used.
+# [auth.hook.custom_access_token]
+# enabled = true
+# uri = "pg-functions://<database>/<schema>/<hook_name>"
+
+# Configure one of the supported SMS providers: `twilio`, `twilio_verify`, `messagebird`, `textlocal`, `vonage`.
+[auth.sms.twilio]
+enabled = false
+account_sid = ""
+message_service_sid = ""
+# DO NOT commit your Twilio auth token to git. Use environment variable substitution instead:
+auth_token = "env(SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN)"
+
+# Multi-factor-authentication is available to Supabase Pro plan.
+[auth.mfa]
+# Control how many MFA factors can be enrolled at once per user.
+max_enrolled_factors = 10
+
+# Control MFA via App Authenticator (TOTP)
+[auth.mfa.totp]
+enroll_enabled = false
+verify_enabled = false
+
+# Configure MFA via Phone Messaging
+[auth.mfa.phone]
+enroll_enabled = false
+verify_enabled = false
+otp_length = 6
+template = "Your code is {{ `{{ .Code }}` }}"
+max_frequency = "5s"
+
+# Configure MFA via WebAuthn
+# [auth.mfa.web_authn]
+# enroll_enabled = true
+# verify_enabled = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `keycloak`, `linkedin_oidc`, `notion`, `twitch`,
+# `twitter`, `x`, `slack`, `spotify`, `workos`, `zoom`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+# DO NOT commit your OAuth provider secret to git. Use environment variable substitution instead:
+secret = "env(SUPABASE_AUTH_EXTERNAL_APPLE_SECRET)"
+# Overrides the default auth callback URL derived from auth.external_url.
+redirect_uri = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""
+# If enabled, the nonce check will be skipped. Required for local sign in with Google auth.
+skip_nonce_check = false
+# If enabled, it will allow the user to successfully authenticate when the provider does not return an email address.
+email_optional = false
+
+# Allow Solana wallet holders to sign in to your project via the Sign in with Solana (SIWS, EIP-4361) standard.
+# You can configure "web3" rate limit in the [auth.rate_limit] section and set up [auth.captcha] if self-hosting.
+[auth.web3.solana]
+enabled = false
+
+# Use Firebase Auth as a third-party provider alongside Supabase Auth.
+[auth.third_party.firebase]
+enabled = false
+# project_id = "my-firebase-project"
+
+# Use Auth0 as a third-party provider alongside Supabase Auth.
+[auth.third_party.auth0]
+enabled = false
+# tenant = "my-auth0-tenant"
+# tenant_region = "us"
+
+# Use AWS Cognito (Amplify) as a third-party provider alongside Supabase Auth.
+[auth.third_party.aws_cognito]
+enabled = false
+# user_pool_id = "my-user-pool-id"
+# user_pool_region = "us-east-1"
+
+# Use Clerk as a third-party provider alongside Supabase Auth.
+[auth.third_party.clerk]
+enabled = false
+# Obtain from https://clerk.com/setup/supabase
+# domain = "example.clerk.accounts.dev"
+
+# OAuth server configuration
+[auth.oauth_server]
+# Enable OAuth server functionality
+enabled = false
+# Path for OAuth consent flow UI
+authorization_url_path = "/oauth/consent"
+# Allow dynamic client registration
+allow_dynamic_registration = false
+
+[edge_runtime]
+enabled = true
+# Supported request policies: `oneshot`, `per_worker`.
+# `per_worker` (default) — enables hot reload during local development.
+# `oneshot` — fallback mode if hot reload causes issues (e.g. in large repos or with symlinks).
+policy = "per_worker"
+# Port to attach the Chrome inspector for debugging edge functions.
+inspector_port = 8083
+# The Deno major version to use.
+deno_version = 2
+
+# [edge_runtime.secrets]
+# secret_key = "env(SECRET_VALUE)"
+
+[analytics]
+enabled = true
+port = 54327
+# Configure one of the supported backends: `postgres`, `bigquery`.
+backend = "postgres"
+
+# Experimental features may be deprecated any time
+[experimental]
+# Configures Postgres storage engine to use OrioleDB (S3)
+orioledb_version = ""
+# Configures S3 bucket URL, eg. <bucket_name>.s3-<region>.amazonaws.com
+s3_host = "env(S3_HOST)"
+# Configures S3 bucket region, eg. us-east-1
+s3_region = "env(S3_REGION)"
+# Configures AWS_ACCESS_KEY_ID for S3 bucket
+s3_access_key = "env(S3_ACCESS_KEY)"
+# Configures AWS_SECRET_ACCESS_KEY for S3 bucket
+s3_secret_key = "env(S3_SECRET_KEY)"
+
+# pg-delta is the schema diff engine for db diff / db pull / db remote commit.
+# Set enabled = false to fall back to the legacy migra engine.
+[experimental.pgdelta]
+enabled = true
+# Directory under `supabase/` where declarative files are written.
+# declarative_schema_path = "./database"
+# JSON string passed through to pg-delta SQL formatting.
+# format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"

--- a/supabase/migrations/20260718170000_baseline_schema.sql
+++ b/supabase/migrations/20260718170000_baseline_schema.sql
@@ -1,0 +1,53 @@
+create table if not exists public.combo_leaderboard (
+  user_id uuid primary key references auth.users (id) on delete cascade,
+  player_name text not null,
+  high_score integer not null default 0 check (high_score >= 0),
+  max_combo integer not null default 0 check (max_combo >= 0),
+  games_played integer not null default 0 check (games_played >= 0),
+  wins integer not null default 0 check (wins >= 0),
+  losses integer not null default 0 check (losses >= 0),
+  ties integer not null default 0 check (ties >= 0),
+  experience integer not null default 0 check (experience >= 0),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.combo_leaderboard enable row level security;
+
+create table if not exists public.friendships (
+  id uuid primary key default gen_random_uuid(),
+  created_at timestamptz not null default now(),
+  user_id uuid not null references auth.users (id) on delete cascade,
+  friend_id uuid not null references auth.users (id) on delete cascade,
+  constraint friendships_no_self check (user_id <> friend_id)
+);
+
+create unique index if not exists friendships_unique_pair_idx
+on public.friendships (
+  least(user_id, friend_id),
+  greatest(user_id, friend_id)
+);
+
+alter table public.friendships enable row level security;
+
+grant select, insert, delete on table public.friendships to authenticated;
+
+drop policy if exists "Users can read their friendships" on public.friendships;
+create policy "Users can read their friendships"
+on public.friendships
+for select
+to authenticated
+using ((select auth.uid()) = user_id or (select auth.uid()) = friend_id);
+
+drop policy if exists "Users can add their friendships" on public.friendships;
+create policy "Users can add their friendships"
+on public.friendships
+for insert
+to authenticated
+with check ((select auth.uid()) = user_id and user_id <> friend_id);
+
+drop policy if exists "Users can remove their friendships" on public.friendships;
+create policy "Users can remove their friendships"
+on public.friendships
+for delete
+to authenticated
+using ((select auth.uid()) = user_id or (select auth.uid()) = friend_id);


### PR DESCRIPTION
## What changed

- tracks local Supabase CLI configuration and a clean-clone baseline migration
- adds pinned start, reset, and type-generation commands
- regenerates checked-in database types
- uses a project-reference placeholder in public documentation

## Why

Local schema restoration should be reproducible without publishing hosted project metadata or credentials.

## Validation

- clean local Supabase start and database reset
- local type generation
- application build on the equivalent audited commit
- Gitleaks commit-range scan

Refs #47
