### PR TITLE
chore(provider): consolidate Atomize ownership

### DIFF
--- a/PROVIDERS.md
+++ b/PROVIDERS.md
@@ -1,0 +1,22 @@
+# Provider ownership
+
+Atomize has one production provider path:
+
+- GitHub repository `Hsiii/atomize`, branch `main`, is the source of truth.
+- Vercel project `Hsi's Lab / atomize` owns the public web deployment. Git
+  integration deploys `main`, and the tracked `vercel.json` owns build and
+  routing configuration.
+- Supabase project `Hsi's Lab / Atomize` owns authentication, PostgreSQL data,
+  Realtime, and Storage. Vercel supplies `VITE_SUPABASE_URL` and
+  `VITE_SUPABASE_ANON_KEY` to Development, Preview, and Production. Atomize
+  does not use a Vercel Marketplace database resource.
+
+Provider project IDs, project references, keys, and tokens stay in provider
+storage or ignored local state. The checkout is intentionally unlinked from
+hosted Supabase by default. `bun run backend:reset` includes `--local`; use the
+separate `backend:types:remote` command only after an explicit maintainer link.
+
+Within the `Hsi's Lab` Supabase organization, Atomize is the one active project
+allocated to this repository. Keep the second free-project slot unused. Projects
+owned by another Supabase organization are outside Atomize's lifecycle and must
+not be changed as part of this repository's maintenance.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ and `supabase/.env*.local`. Never commit a service-role key.
 The CLI exposes its development ports on the host, so use this stack only on a
 trusted network with the host firewall enabled and stop it when finished.
 
+Production provider ownership and capacity boundaries are recorded in
+[`PROVIDERS.md`](PROVIDERS.md).
+
 ## Godot mobile port
 
 The parallel Godot iOS/Android port lives in `godot/`. The Vite app remains the

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,7 @@ export default defineConfig(
     ...completeConfigBase,
 
     {
-        ignores: ['public/theme-init.js'],
+        ignores: ['public/theme-init.js', 'src/lib/database.types.ts'],
     },
 
     {


### PR DESCRIPTION
## Description

- document the single GitHub → Vercel → Supabase production ownership path without provider IDs or secrets
- reserve the unused second Supabase free-project slot and exclude projects owned by other organizations from Atomize maintenance
- keep generated Supabase types out of ESLint while retaining TypeScript build checks
- remove obsolete Vercel dashboard build/output overrides after confirming the root `vercel.json` deployment is live
